### PR TITLE
Removed the selector line in order for the example to work

### DIFF
--- a/functions/chrome/chrome.js
+++ b/functions/chrome/chrome.js
@@ -24,8 +24,6 @@ exports.handler = async (event, context, callback) => {
       waitUntil: ["domcontentloaded", "networkidle0"]
     })
 
-    await page.waitForSelector('#phenomic')
-
     theTitle = await page.title();
 
     console.log('done on page', theTitle)


### PR DESCRIPTION
Removing the wait for selector line because the #phenomic is not present anymore on the webpage that is targetted. 