### PR TITLE
Fix selector div id

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ exports.handler = async (event, context, callback) => {
       waitUntil: ["domcontentloaded", "networkidle0"]
     })
 
-    await page.waitForSelector('#phenomic')
+    await page.waitForSelector('#___gatsby')
 
     theTitle = await page.title();
 

--- a/functions/chrome/chrome.js
+++ b/functions/chrome/chrome.js
@@ -24,7 +24,7 @@ exports.handler = async (event, context, callback) => {
       waitUntil: ["domcontentloaded", "networkidle0"]
     })
 
-    await page.waitForSelector('#phenomic')
+    await page.waitForSelector('#___gatsby')
 
     theTitle = await page.title();
 


### PR DESCRIPTION
This PR fixes the example code, `#phenomic` is no longer a valid div id on davidwells.io.